### PR TITLE
Move Alt PHP methods in base module to separate class as static methods

### DIFF
--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -263,8 +263,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		 * @throws BadMethodCallException
 		 */
 		function __call( $name, $arguments ) {
-			if ( $this->strpos( $name, 'display_settings_page_' ) === 0 ) {
-				return $this->display_settings_page( $this->substr( $name, 22 ) );
+			if ( AIOSEOP_PHP_Functions::strpos( $name, 'display_settings_page_' ) === 0 ) {
+				return $this->display_settings_page( AIOSEOP_PHP_Functions::substr( $name, 22 ) );
 			}
 			$error = sprintf( __( "Method %s doesn't exist", 'all-in-one-seo-pack' ), $name );
 			if ( class_exists( 'BadMethodCallException' ) ) {
@@ -380,168 +380,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 			$opt    = $prefix . $option;
 
 			return ( isset( $this->options[ $opt ] ) && $this->options[ $opt ] );
-		}
-
-		/**
-		 * Case conversion; handle non UTF-8 encodings and fallback **
-		 *
-		 * @param        $str
-		 * @param string $mode
-		 *
-		 * @return string
-		 */
-
-		function convert_case( $str, $mode = 'upper' ) {
-			static $charset = null;
-			if ( null == $charset ) {
-				$charset = get_bloginfo( 'charset' );
-			}
-			$str = (string) $str;
-			if ( 'title' == $mode ) {
-				if ( function_exists( 'mb_convert_case' ) ) {
-					return mb_convert_case( $str, MB_CASE_TITLE, $charset );
-				} else {
-					return ucwords( $str );
-				}
-			}
-
-			if ( 'UTF-8' == $charset ) {
-				// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				global $UTF8_TABLES;
-				include_once( AIOSEOP_PLUGIN_DIR . 'inc/aioseop_UTF8.php' );
-				if ( is_array( $UTF8_TABLES ) ) {
-					if ( 'upper' == $mode ) {
-						return strtr( $str, $UTF8_TABLES['strtoupper'] );
-					}
-					if ( 'lower' == $mode ) {
-						return strtr( $str, $UTF8_TABLES['strtolower'] );
-					}
-				}
-				// phpcs:enable
-			}
-
-			if ( 'upper' == $mode ) {
-				if ( function_exists( 'mb_strtoupper' ) ) {
-					return mb_strtoupper( $str, $charset );
-				} else {
-					return strtoupper( $str );
-				}
-			}
-
-			if ( 'lower' == $mode ) {
-				if ( function_exists( 'mb_strtolower' ) ) {
-					return mb_strtolower( $str, $charset );
-				} else {
-					return strtolower( $str );
-				}
-			}
-
-			return $str;
-		}
-
-		/**
-		 * Convert a string to lower case
-		 * Compatible with mb_strtolower(), an UTF-8 friendly replacement for strtolower()
-		 *
-		 * @param $str
-		 *
-		 * @return string
-		 */
-		function strtolower( $str ) {
-			return $this->convert_case( $str, 'lower' );
-		}
-
-		/**
-		 * Convert a string to upper case
-		 * Compatible with mb_strtoupper(), an UTF-8 friendly replacement for strtoupper()
-		 *
-		 * @param $str
-		 *
-		 * @return string
-		 */
-		function strtoupper( $str ) {
-			return $this->convert_case( $str, 'upper' );
-		}
-
-		/**
-		 * Convert a string to title case
-		 * Compatible with mb_convert_case(), an UTF-8 friendly replacement for ucwords()
-		 *
-		 * @param $str
-		 *
-		 * @return string
-		 */
-		function ucwords( $str ) {
-			return $this->convert_case( $str, 'title' );
-		}
-
-		/**
-		 * Wrapper for strlen() - uses mb_strlen() if possible.
-		 *
-		 * @param $string
-		 *
-		 * @return int
-		 */
-		function strlen( $string ) {
-			if ( function_exists( 'mb_strlen' ) ) {
-				return mb_strlen( $string, 'UTF-8' );
-			}
-
-			return strlen( $string );
-		}
-
-		/**
-		 * Wrapper for substr() - uses mb_substr() if possible.
-		 *
-		 * @param     $string
-		 * @param int $start
-		 * @param int $length
-		 *
-		 * @return mixed
-		 */
-		function substr( $string, $start = 0, $length = 2147483647 ) {
-			$args = func_get_args();
-			if ( function_exists( 'mb_substr' ) ) {
-				return call_user_func_array( 'mb_substr', $args );
-			}
-
-			return call_user_func_array( 'substr', $args );
-		}
-
-		/**
-		 * Wrapper for strpos() - uses mb_strpos() if possible.
-		 *
-		 * @param        $haystack
-		 * @param string $needle
-		 *
-		 * @param int    $offset
-		 *
-		 * @return bool|int
-		 */
-		function strpos( $haystack, $needle, $offset = 0 ) {
-			if ( function_exists( 'mb_strpos' ) ) {
-				return mb_strpos( $haystack, $needle, $offset, 'UTF-8' );
-			}
-
-			return strpos( $haystack, $needle, $offset );
-		}
-
-		/**
-		 * Wrapper for strrpos() - uses mb_strrpos() if possible.
-		 *
-		 * @param        $haystack
-		 * @param string $needle
-		 *
-		 * @param int    $offset
-		 *
-		 * @return bool|int
-		 */
-		function strrpos( $haystack, $needle, $offset = 0 ) {
-			if ( function_exists( 'mb_strrpos' ) ) {
-				return mb_strrpos( $haystack, $needle, $offset, 'UTF-8' );
-			}
-
-			return strrpos( $haystack, $needle, $offset );
 		}
 
 		/**
@@ -1172,7 +1010,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 
 				if ( is_array( $post_custom_fields ) ) {
 					foreach ( $post_custom_fields as $field_name => $field ) {
-						if ( ( $this->strpos( $field_name, $prefix ) === 0 ) && $field[0] ) {
+						if ( ( AIOSEOP_PHP_Functions::strpos( $field_name, $prefix ) === 0 ) && $field[0] ) {
 							$has_data = true;
 							$data    .= $field_name . " = '" . $field[0] . "'\n";
 						}
@@ -1475,9 +1313,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 						return $file;
 					}
 					if ( 0 > $maxlen ) {
-						return $this->substr( $file, $offset );
+						return AIOSEOP_PHP_Functions::substr( $file, $offset );
 					} else {
-						return $this->substr( $file, $offset, $maxlen );
+						return AIOSEOP_PHP_Functions::substr( $file, $offset, $maxlen );
 					}
 				} else {
 					return $wpfs->get_contents( $filename );
@@ -2222,8 +2060,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		 */
 		function add_page_hooks() {
 			$hookname = current_filter();
-			if ( $this->strpos( $hookname, 'load-' ) === 0 ) {
-				$this->pagehook = $this->substr( $hookname, 5 );
+			if ( AIOSEOP_PHP_Functions::strpos( $hookname, 'load-' ) === 0 ) {
+				$this->pagehook = AIOSEOP_PHP_Functions::substr( $hookname, 5 );
 			}
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ) );
@@ -2748,8 +2586,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 					/* translators: %1$s and %2$s are placeholders and should not be translated. %1$s is replaced with a number, %2$s is replaced with the name of an meta tag field (e.g; "Title", "Description", etc.). */
 					$count_desc = __( ' characters. Most search engines use a maximum of %1$s chars for the %2$s.', 'all-in-one-seo-pack' );
 				}
-				$buf .= "<br /><input readonly tabindex='-1' type='text' name='{$prefix}length$n' size='3' maxlength='3' style='width:53px;height:23px;margin:0px;padding:0px 0px 0px 10px;' value='" . $this->strlen( $value ) . "' />"
-						. sprintf( $count_desc, $size, trim( $this->strtolower( $options['name'] ), ':' ) );
+				$buf .= "<br /><input readonly tabindex='-1' type='text' name='{$prefix}length$n' size='3' maxlength='3' style='width:53px;height:23px;margin:0px;padding:0px 0px 0px 10px;' value='" . AIOSEOP_PHP_Functions::strlen( $value ) . "' />"
+						. sprintf( $count_desc, $size, trim( AIOSEOP_PHP_Functions::strtolower( $options['name'] ), ':' ) );
 				if ( ! empty( $onload ) ) {
 					$buf .= "<script>jQuery( document ).ready(function() { {$onload} });</script>";
 				}
@@ -2930,11 +2768,11 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		 */
 		function sanitize_domain( $domain ) {
 			$domain = trim( $domain );
-			$domain = $this->strtolower( $domain );
-			if ( 0 === $this->strpos( $domain, 'http://' ) ) {
-				$domain = $this->substr( $domain, 7 );
-			} elseif ( 0 === $this->strpos( $domain, 'https://' ) ) {
-				$domain = $this->substr( $domain, 8 );
+			$domain = AIOSEOP_PHP_Functions::strtolower( $domain );
+			if ( 0 === AIOSEOP_PHP_Functions::strpos( $domain, 'http://' ) ) {
+				$domain = AIOSEOP_PHP_Functions::substr( $domain, 7 );
+			} elseif ( 0 === AIOSEOP_PHP_Functions::strpos( $domain, 'https://' ) ) {
+				$domain = AIOSEOP_PHP_Functions::substr( $domain, 8 );
 			}
 			$domain = untrailingslashit( $domain );
 
@@ -3295,7 +3133,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 			if ( ! empty( $options ) ) {
 				foreach ( $options as $k => $v ) {
 					if ( ! isset( $v['name'] ) ) {
-						$v['name'] = $this->ucwords( strtr( $k, '_', ' ' ) );
+						$v['name'] = AIOSEOP_PHP_Functions::ucwords( strtr( $k, '_', ' ' ) );
 					}
 					if ( ! isset( $v['type'] ) ) {
 						$v['type'] = 'checkbox';

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1224,13 +1224,13 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		$w                         = $info['w'];
 		$p                         = $info['p'];
 
-		if ( $this->strlen( $title ) > 70 ) {
+		if ( AIOSEOP_PHP_Functions::strlen( $title ) > 70 ) {
 			$title = $this->trim_excerpt_without_filters(
 				$this->html_entity_decode( $title ),
 				70
 			) . '...';
 		}
-		if ( $this->strlen( $description ) > 156 ) {
+		if ( AIOSEOP_PHP_Functions::strlen( $description ) > 156 ) {
 			$description = $this->trim_excerpt_without_filters(
 				$this->html_entity_decode( $description ),
 				156
@@ -2141,7 +2141,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$search = esc_attr( stripslashes( $s ) );
 			$title  = $search;
 		} elseif ( ( is_tax() || is_category() ) && ! is_feed() ) {
-			$category_name = $this->ucwords( $this->internationalize( single_cat_title( '', false ) ) );
+			$category_name = AIOSEOP_PHP_Functions::ucwords( $this->internationalize( single_cat_title( '', false ) ) );
 			$title         = $category_name;
 		} elseif ( is_page() ) {
 			$title = $this->internationalize( single_post_title( '', false ) );
@@ -2217,7 +2217,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		$request_a   = explode( ' ', $request );
 		$request_new = array();
 		foreach ( $request_a as $token ) {
-			$request_new[] = $this->ucwords( trim( $token ) );
+			$request_new[] = AIOSEOP_PHP_Functions::ucwords( trim( $token ) );
 		}
 		$request = implode( ' ', $request_new );
 
@@ -2319,10 +2319,10 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$new_title = str_replace( "%{$type}_author_nicename%", $authordata->user_nicename, $new_title );
 		}
 		if ( false !== strpos( $new_title, "%{$type}_author_firstname%", 0 ) ) {
-			$new_title = str_replace( "%{$type}_author_firstname%", $this->ucwords( $authordata->first_name ), $new_title );
+			$new_title = str_replace( "%{$type}_author_firstname%", AIOSEOP_PHP_Functions::ucwords( $authordata->first_name ), $new_title );
 		}
 		if ( false !== strpos( $new_title, "%{$type}_author_lastname%", 0 ) ) {
-			$new_title = str_replace( "%{$type}_author_lastname%", $this->ucwords( $authordata->last_name ), $new_title );
+			$new_title = str_replace( "%{$type}_author_lastname%", AIOSEOP_PHP_Functions::ucwords( $authordata->last_name ), $new_title );
 		}
 		if ( false !== strpos( $new_title, '%current_date%', 0 ) ) {
 			$new_title = str_replace( '%current_date%', aioseop_formatted_date(), $new_title );
@@ -3000,7 +3000,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$max = $this->maximum_description_length;
 		}
 		$max_orig = $max;
-		$len      = $this->strlen( $text2 );
+		$len      = AIOSEOP_PHP_Functions::strlen( $text2 );
 		if ( $max < $len ) {
 			if ( function_exists( 'mb_strrpos' ) ) {
 				$pos = mb_strrpos( $text2, ' ', - ( $len - $max ), 'UTF-8' );
@@ -3023,7 +3023,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				$max = $max_orig;
 			}
 		}
-		$text = $this->substr( $text, 0, $max );
+		$text = AIOSEOP_PHP_Functions::substr( $text, 0, $max );
 
 		return trim( $text );
 	}
@@ -3055,15 +3055,15 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 		if ( get_query_var( 'm' ) ) {
 			$m = preg_replace( '/[^0-9]/', '', get_query_var( 'm' ) );
-			switch ( $this->strlen( $m ) ) {
+			switch ( AIOSEOP_PHP_Functions::strlen( $m ) ) {
 				case 4:
 					$link = get_year_link( $m );
 					break;
 				case 6:
-					$link = get_month_link( $this->substr( $m, 0, 4 ), $this->substr( $m, 4, 2 ) );
+					$link = get_month_link( AIOSEOP_PHP_Functions::substr( $m, 0, 4 ), AIOSEOP_PHP_Functions::substr( $m, 4, 2 ) );
 					break;
 				case 8:
-					$link = get_day_link( $this->substr( $m, 0, 4 ), $this->substr( $m, 4, 2 ), $this->substr( $m, 6, 2 ) );
+					$link = get_day_link( AIOSEOP_PHP_Functions::substr( $m, 0, 4 ), AIOSEOP_PHP_Functions::substr( $m, 4, 2 ), AIOSEOP_PHP_Functions::substr( $m, 6, 2 ) );
 					break;
 				default:
 					return false;
@@ -3364,7 +3364,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 		if ( ! empty( $keywords ) ) {
 			foreach ( $keywords as $word ) {
-				$small_keywords[] = trim( $this->strtolower( $word ) );
+				$small_keywords[] = trim( AIOSEOP_PHP_Functions::strtolower( $word ) );
 			}
 		}
 
@@ -4095,8 +4095,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		$title             = trim( strip_tags( $title ) );
 		$title_tag_start   = '<title';
 		$title_tag_end     = '</title';
-		$start             = $this->strpos( $content, $title_tag_start, 0 );
-		$end               = $this->strpos( $content, $title_tag_end, 0 );
+		$start             = AIOSEOP_PHP_Functions::strpos( $content, $title_tag_start, 0 );
+		$end               = AIOSEOP_PHP_Functions::strpos( $content, $title_tag_end, 0 );
 		$this->title_start = $start;
 		$this->title_end   = $end;
 		$this->orig_title  = $title;
@@ -4299,7 +4299,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		global $aioseop_options;
 
 		// Handle the description format.
-		if ( isset( $description ) && false !== $description && ( $this->strlen( $description ) > $this->minimum_description_length ) && ! ( is_front_page() && is_paged() ) ) {
+		if ( isset( $description ) && false !== $description && ( AIOSEOP_PHP_Functions::strlen( $description ) > $this->minimum_description_length ) && ! ( is_front_page() && is_paged() ) ) {
 			$description = $this->trim_description( $description );
 			if ( ! isset( $meta_string ) ) {
 				$meta_string = '';
@@ -4664,7 +4664,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			}
 			if (
 					sizeof( $active_handlers ) > 0 &&
-					$this->strtolower( $active_handlers[ sizeof( $active_handlers ) - 1 ] ) == $this->strtolower( 'All_in_One_SEO_Pack::output_callback_for_title' )
+					AIOSEOP_PHP_Functions::strtolower( $active_handlers[ sizeof( $active_handlers ) - 1 ] ) == AIOSEOP_PHP_Functions::strtolower( 'All_in_One_SEO_Pack::output_callback_for_title' )
 			) {
 				ob_end_flush();
 			} else {

--- a/class-aioseop-core.php
+++ b/class-aioseop-core.php
@@ -322,6 +322,7 @@ class AIOSEOP_Core {
 		require_once AIOSEOP_PLUGIN_DIR . 'inc/compatibility/abstract/aiosep_compatible.php';
 		require_once AIOSEOP_PLUGIN_DIR . 'inc/compatibility/compat-init.php';
 		require_once AIOSEOP_PLUGIN_DIR . 'inc/compatibility/php-functions.php';
+		require_once AIOSEOP_PLUGIN_DIR . 'inc/compatibility/class-aioseop-php-functions.php';
 		require_once AIOSEOP_PLUGIN_DIR . 'public/front.php';
 		require_once AIOSEOP_PLUGIN_DIR . 'public/google-analytics.php';
 		require_once AIOSEOP_PLUGIN_DIR . 'admin/display/welcome.php';

--- a/inc/compatibility/class-aioseop-php-functions.php
+++ b/inc/compatibility/class-aioseop-php-functions.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * AIOSEOP_PHP_Functions class
+ *
+ * Alternative PHP functions for improved operations or compatibility with pre-existing functions that had param changes.
+ *
+ * @package All-in-One-SEO-Pack
+ * @since 3.4.0
+ */
+
+/**
+ * Class AIOSEOP_PHP_Functions
+ *
+ * Access to these methods is done statically.
+ * Adding any additional methods for PHP functions should be reserved only for pre-existing functions.
+ * Any non-existing functions in older PHP versions should use `inc/compatibility/php-functions.php`.
+ *
+ * @since 3.4.0
+ */
+class AIOSEOP_PHP_Functions {
+
+	/**
+	 * Convert a string to lower case
+	 * Compatible with mb_strtolower(), an UTF-8 friendly replacement for strtolower()
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param string $str
+	 * @return string
+	 */
+	public static function strtolower( $str ) {
+		return AIOSEOP_PHP_Functions::convert_case( $str, 'lower' );
+	}
+
+	/**
+	 * Convert a string to upper case
+	 * Compatible with mb_strtoupper(), an UTF-8 friendly replacement for strtoupper()
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param string $str
+	 * @return string
+	 */
+	public static function strtoupper( $str ) {
+		return AIOSEOP_PHP_Functions::convert_case( $str, 'upper' );
+	}
+
+	/**
+	 * Convert a string to title case
+	 * Compatible with mb_convert_case(), an UTF-8 friendly replacement for ucwords()
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param string $str
+	 * @return string
+	 */
+	public static function ucwords( $str ) {
+		return AIOSEOP_PHP_Functions::convert_case( $str, 'title' );
+	}
+
+	/**
+	 * Case conversion; handle non UTF-8 encodings and fallback **
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param string $str
+	 * @param string $mode
+	 * @return string
+	 */
+	private static function convert_case( $str, $mode = 'upper' ) {
+		static $charset = null;
+		if ( null == $charset ) {
+			$charset = get_bloginfo( 'charset' );
+		}
+		$str = (string) $str;
+		if ( 'title' == $mode ) {
+			if ( function_exists( 'mb_convert_case' ) ) {
+				return mb_convert_case( $str, MB_CASE_TITLE, $charset );
+			} else {
+				return ucwords( $str );
+			}
+		}
+
+		if ( 'UTF-8' == $charset ) {
+			// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			global $UTF8_TABLES;
+			include_once( AIOSEOP_PLUGIN_DIR . 'inc/aioseop_UTF8.php' );
+			if ( is_array( $UTF8_TABLES ) ) {
+				if ( 'upper' == $mode ) {
+					return strtr( $str, $UTF8_TABLES['strtoupper'] );
+				}
+				if ( 'lower' == $mode ) {
+					return strtr( $str, $UTF8_TABLES['strtolower'] );
+				}
+			}
+			// phpcs:enable
+		}
+
+		if ( 'upper' == $mode ) {
+			if ( function_exists( 'mb_strtoupper' ) ) {
+				return mb_strtoupper( $str, $charset );
+			} else {
+				return strtoupper( $str );
+			}
+		}
+
+		if ( 'lower' == $mode ) {
+			if ( function_exists( 'mb_strtolower' ) ) {
+				return mb_strtolower( $str, $charset );
+			} else {
+				return strtolower( $str );
+			}
+		}
+
+		return $str;
+	}
+
+	/**
+	 * Wrapper for strlen() - uses mb_strlen() if possible.
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param $string
+	 * @return int
+	 */
+	public static function strlen( $string ) {
+		if ( function_exists( 'mb_strlen' ) ) {
+			return mb_strlen( $string, 'UTF-8' );
+		}
+
+		return strlen( $string );
+	}
+
+	/**
+	 * Wrapper for substr() - uses mb_substr() if possible.
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param     $string
+	 * @param int $start
+	 * @param int $length
+	 * @return mixed
+	 */
+	public static function substr( $string, $start = 0, $length = 2147483647 ) {
+		$args = func_get_args();
+		if ( function_exists( 'mb_substr' ) ) {
+			return call_user_func_array( 'mb_substr', $args );
+		}
+
+		return call_user_func_array( 'substr', $args );
+	}
+
+	/**
+	 * Wrapper for strpos() - uses mb_strpos() if possible.
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param        $haystack
+	 * @param string $needle
+	 * @param int    $offset
+	 * @return bool|int
+	 */
+	public static function strpos( $haystack, $needle, $offset = 0 ) {
+		if ( function_exists( 'mb_strpos' ) ) {
+			return mb_strpos( $haystack, $needle, $offset, 'UTF-8' );
+		}
+
+		return strpos( $haystack, $needle, $offset );
+	}
+
+	/**
+	 * Wrapper for strrpos() - uses mb_strrpos() if possible.
+	 *
+	 * @since ?
+	 * @since 3.4.0 Change to static method.
+	 *
+	 * @param        $haystack
+	 * @param string $needle
+	 * @param int    $offset
+	 * @return bool|int
+	 */
+	public static function strrpos( $haystack, $needle, $offset = 0 ) {
+		if ( function_exists( 'mb_strrpos' ) ) {
+			return mb_strrpos( $haystack, $needle, $offset, 'UTF-8' );
+		}
+
+		return strrpos( $haystack, $needle, $offset );
+	}
+}

--- a/modules/aioseop_bad_robots.php
+++ b/modules/aioseop_bad_robots.php
@@ -165,12 +165,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Bad_Robots' ) ) {
 				$this->options[ "{$this->prefix}blocked_log" ] = '';
 			}
 			$this->options[ "{$this->prefix}blocked_log" ] = date( 'Y-m-d H:i:s' ) . " {$msg}\n" . $this->options[ "{$this->prefix}blocked_log" ];
-			if ( $this->strlen( $this->options[ "{$this->prefix}blocked_log" ] ) > 4096 ) {
-				$end = $this->strrpos( $this->options[ "{$this->prefix}blocked_log" ], "\n" );
+			if ( AIOSEOP_PHP_Functions::strlen( $this->options[ "{$this->prefix}blocked_log" ] ) > 4096 ) {
+				$end = AIOSEOP_PHP_Functions::strrpos( $this->options[ "{$this->prefix}blocked_log" ], "\n" );
 				if ( false === $end ) {
 					$end = 4096;
 				}
-				$this->options[ "{$this->prefix}blocked_log" ] = $this->substr( $this->options[ "{$this->prefix}blocked_log" ], 0, $end );
+				$this->options[ "{$this->prefix}blocked_log" ] = AIOSEOP_PHP_Functions::substr( $this->options[ "{$this->prefix}blocked_log" ], 0, $end );
 			}
 			$this->update_class_option( $this->options );
 		}

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -1625,11 +1625,11 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 			if ( isset( $extra_params['auto_generate_desc'] ) && $extra_params['auto_generate_desc'] ) {
 				switch ( $meta_tag ) {
 					case 'twitter:title':
-						$value = trim( $this->substr( $value, 0, 70 ) );
+						$value = trim( AIOSEOP_PHP_Functions::substr( $value, 0, 70 ) );
 						break;
 					case 'og:description':
 					case 'twitter:description':
-						$value = trim( $this->substr( $value, 0, 200 ) );
+						$value = trim( AIOSEOP_PHP_Functions::substr( $value, 0, 200 ) );
 						break;
 				}
 			}

--- a/modules/aioseop_performance.php
+++ b/modules/aioseop_performance.php
@@ -270,7 +270,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Performance' ) ) {
 				$memory_usage = __( 'N/A', 'all-in-one-seo-pack' );
 			}
 			if ( is_callable( 'exif_read_data' ) ) {
-				$exif = __( 'Yes', 'all-in-one-seo-pack' ) . ' ( V' . $this->substr( phpversion( 'exif' ), 0, 4 ) . ')';
+				$exif = __( 'Yes', 'all-in-one-seo-pack' ) . ' ( V' . AIOSEOP_PHP_Functions::substr( phpversion( 'exif' ), 0, 4 ) . ')';
 			} else {
 				$exif = __( 'No', 'all-in-one-seo-pack' );
 			}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -279,7 +279,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 					}
 
 					$arr[ $k . '_' . $opt ] = array(
-						'name'            => $this->ucwords( $val ),
+						'name'            => AIOSEOP_PHP_Functions::ucwords( $val ),
 						'type'            => 'select',
 						'initial_options' => $iopts,
 						'default'         => 'no',
@@ -1350,7 +1350,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				if ( $this->is_file( $f ) ) {
 					$fn         = $f;
 					$compressed = false;
-					if ( $this->substr( $f, - 3 ) === '.gz' ) {
+					if ( AIOSEOP_PHP_Functions::substr( $f, - 3 ) === '.gz' ) {
 						$compressed = true;
 					}
 					if ( $use_wpfs ) {


### PR DESCRIPTION
Issue #3070 

## Proposed changes

Moves methods in the base module intended for improved/compatible PHP functions into a seperate class as static methods. This would allow access to these function throughout the plugin and centralize alternate PHP functions/methods.

## Types of changes

What types of changes does your code introduce?

- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions

Code Refactor.

Changes are part of base module operations, so any testing would be with general use of the plugin.


