### PR TITLE
Fix invalid CSS ending

### DIFF
--- a/css/aiosp_admin.css
+++ b/css/aiosp_admin.css
@@ -444,3 +444,4 @@ label[for=aioseop_edit_profile_header] {
 	float:left;
 	width:20px;
 	margin-right:5px;
+}


### PR DESCRIPTION
## Proposed changes

https://github.com/awesomemotive/all-in-one-seo-pack/blob/a65d0c009cbf682a50d910fbde3e1161bd3a5e34/css/aiosp_admin.css#L440-L446

End of stylesheet, there is no closing bracket. This is probably not break some browser in simple way, but it breaks css concatting (like [nginx-http-concat](https://github.com/Automattic/nginx-http-concat)).

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist


- [ ] I've selected the appropriate branch (ie x.y rather than master).
  - looks there are no branch...
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] If I added, removed or modified any translatable strings, I updated the commonstrings.php file (free repository) accordingly or else opened an issue for it.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Don't assume the tester knows the entire backstory of the issue, and don't force him/her to decipher the code to try and figure out what -it's doing or how to test it.
- Do provide step by step instructions on how to test. 
- Do note things to watch out for.
- Do note what aspects the tester should try and break.

