### PR TITLE
fix the dashicons stylesheet removing from frontend issue

### DIFF
--- a/app/Common/Main/Head.php
+++ b/app/Common/Main/Head.php
@@ -31,7 +31,7 @@ class Head {
 	public function __construct() {
 		add_action( 'init', [ $this, 'addAnalytics' ] );
 		add_action( 'wp', [ $this, 'registerTitleHooks' ], 1000 );
-		add_action( 'wp_head', [ $this, 'init' ], 1 );
+		add_action( 'wp_head', [ $this, 'init' ], 8 );
 
 		$this->analytics    = new GoogleAnalytics();
 		$this->links        = new Meta\Links();


### PR DESCRIPTION
Previously, AIOSEO removes the `dashicons` stylesheet from frontend pages. Which results missing dashicons icons.

Now, fixed the issue in this PR.

Fix: #3196 