### PR TITLE
Fix for nullable cacheTableName in Database class

### DIFF
--- a/app/Common/Models/Model.php
+++ b/app/Common/Models/Model.php
@@ -452,7 +452,8 @@ class Model implements \JsonSerializable {
 
 			// Let's set the columns that are available by default.
 			$table   = aioseo()->core->db->prefix . $this->table;
-			$results = aioseo()->core->db
+			$results = aioseo()->core->db 
+                		->start( $table )
 				->output( 'OBJECT' )
 				->execute( 'SHOW COLUMNS FROM `' . $table . '`', true )
 				->result();


### PR DESCRIPTION
# Proposed changes
AIOSEO\Plugin\Common\Models\Model
Php 8.1. When calling the `getColumns `method, we get an error, because the table for which we are executing the query is not specified.
`Deprecated: stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /wp-content/plugins/all-in-one-seo-pack/app/Common/Utils/Database.php on line 1647`

# Types of changes
Bugfix (non-breaking change which fixes an issue)

