### PR TITLE
Added hooks to change post ID for third party compatibility

### DIFF
--- a/app/Common/Traits/Helpers/WpContext.php
+++ b/app/Common/Traits/Helpers/WpContext.php
@@ -172,6 +172,22 @@ trait WpContext {
 	public function getPost( $postId = false ) {
 		$postId = is_a( $postId, 'WP_Post' ) ? $postId->ID : $postId;
 
+		/**
+		 * Filter: Allow to change post ID.
+		 *
+		 * @see https://github.com/rankmath/seo-by-rank-math/blob/76e87a34fb3a4f325c396251a65d19fd71fac6b5/includes/class-post.php#L97-#L130
+		 *
+		 * @since x.x.x
+		 *
+		 * @param int $postId Post ID.
+		 */
+		$newPostId = apply_filters( 'aioseo_pre_simple_post_id', $postId );
+		$post      = get_post( $newPostId );
+
+		if ( $post ) {
+			return $post;
+		}
+
 		if ( aioseo()->helpers->isWooCommerceShopPage( $postId ) ) {
 			return get_post( wc_get_page_id( 'shop' ) );
 		}


### PR DESCRIPTION
Added hooks to change the post ID for third-party compatibility.  The compatibility with WooCommerce is hard coded, which doesn't allow room for other plugin compatibility. This has been inspired by two other SEO plugins Yoast Seo and Rank Math. I have included their code links as well.

1. Rank Math: https://github.com/rankmath/seo-by-rank-math/blob/76e87a34fb3a4f325c396251a65d19fd71fac6b5/includes/class-post.php#L97-#L130

2. Yoast : https://github.com/Yoast/wordpress-seo/blob/78df60708b2a56387e63cd42c0d0451a5a116e71/src/helpers/current-page-helper.php#L76-#L96